### PR TITLE
provided repo didn't have the `meta-multi-sig` branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ required: [Node](https://nodejs.org/dist/latest-v12.x/) plus [Yarn](https://clas
 
 
 ```bash
-git clone https://github.com/austintgriffith/scaffold-eth.git meta-multi-sig
+git clone https://github.com/scaffold-eth/scaffold-eth-examples meta-multi-sig
 
 cd meta-multi-sig
 


### PR DESCRIPTION
Updating with repo that actually contains the `meta-multi-sig` branch