### PR TITLE
Fix README.md - use the correct github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ## quickstart
 
 ```bash
-git clone https://github.com/austintgriffith/scaffold-eth.git signature-recover
+git clone https://github.com/scaffold-eth/scaffold-eth-examples.git signature-recover
 
 cd signature-recover
 


### PR DESCRIPTION
Hey guys,

The readme points to another repo, where the signature-recover branch contains something else than the current example.

Best,
Tamas