### PR TITLE
Fix link on simple-nft-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Check out all the [active branches](https://github.com/austintgriffith/scaffold-
  - 🚤  [Follow the full Ethereum Speed Run](https://medium.com/@austin_48503/%EF%B8%8Fethereum-dev-speed-run-bd72bcba6a4c)
 
 
- - 🎟  [Create your first NFT](https://github.com/austintgriffith/scaffold-eth/tree/simple-nft-example)
+ - 🎟  [Create your first NFT](https://github.com/scaffold-eth/scaffold-eth-challenges/tree/challenge-0-simple-nft)
  - 🥩  [Build a staking smart contract](https://github.com/austintgriffith/scaffold-eth/tree/challenge-1-decentralized-staking)
  - 🏵  [Deploy a token and vendor](https://github.com/austintgriffith/scaffold-eth/tree/challenge-2-token-vendor)
  - 🎫  [Extend the NFT example to make a "buyer mints" marketplace](https://github.com/austintgriffith/scaffold-eth/tree/buyer-mints-nft)


### PR DESCRIPTION
The existing link points to the old version, it should point to challenge-0